### PR TITLE
feat: redux-toolkit 초기세팅(slice분리 및 store 생성)

### DIFF
--- a/src/app/configureStore.js
+++ b/src/app/configureStore.js
@@ -1,0 +1,15 @@
+import { configureStore } from "@reduxjs/toolkit";
+import logger from "redux-logger";
+
+import tutorialSlice from "../features/tutorial/tutorialSlice";
+import gameSlice from "../features/game/gameSlice";
+
+const store = configureStore({
+  reducer: {
+    tutorial: tutorialSlice.reducer,
+    game: gameSlice.reducer,
+  },
+  middleware: [logger],
+});
+
+export default store;

--- a/src/features/game/gameSlice.js
+++ b/src/features/game/gameSlice.js
@@ -1,0 +1,17 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const gameSlice = createSlice({
+  name: "gameSlice",
+  initialState: {
+    game1: { title: "", mapArray: [] },
+    game2: { title: "", mapArray: [] },
+  },
+  reducers: {
+    updateMap: (state, action) => {
+      state[action.payload.tutorialId.mapArray] = action.payload.mapArray;
+    },
+  },
+});
+
+export default gameSlice;
+export const { updateMap } = gameSlice.actions;

--- a/src/features/game/gameSlice.js
+++ b/src/features/game/gameSlice.js
@@ -8,7 +8,7 @@ const gameSlice = createSlice({
   },
   reducers: {
     updateMap: (state, action) => {
-      state[action.payload.tutorialId.mapArray] = action.payload.mapArray;
+      state[action.payload.gameId].mapArray = action.payload.mapArray;
     },
   },
 });

--- a/src/features/tutorial/tutorialSlice.js
+++ b/src/features/tutorial/tutorialSlice.js
@@ -8,7 +8,7 @@ const tutorialSlice = createSlice({
   },
   reducers: {
     updateMap: (state, action) => {
-      state[action.payload.tutorialId.mapArray] = action.payload.mapArray;
+      state[action.payload.tutorialId].mapArray = action.payload.mapArray;
     },
   },
 });

--- a/src/features/tutorial/tutorialSlice.js
+++ b/src/features/tutorial/tutorialSlice.js
@@ -1,0 +1,17 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const tutorialSlice = createSlice({
+  name: "tutorialSlice",
+  initialState: {
+    tutorial1: { title: "", mapArray: [] },
+    tutorial2: { title: "", mapArray: [] },
+  },
+  reducers: {
+    updateMap: (state, action) => {
+      state[action.payload.tutorialId.mapArray] = action.payload.mapArray;
+    },
+  },
+});
+
+export default tutorialSlice;
+export const { updateMap } = tutorialSlice.actions;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,15 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { Provider } from "react-redux";
+
 import App from "./app/App";
+import store from "./app/configureStore";
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const rootElement = document.getElementById("root");
+const root = createRoot(rootElement);
 
-root.render(<App />);
+root.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+);


### PR DESCRIPTION
### Task Card
- [[Setup] redux 초기 세팅](https://www.notion.so/vanillacoding/Setup-redux-ae712ac7b11e4f869dc157fe179126e2)

### Description
- 관심사에 따른 slice 분리
- slice별 필수 state 설정 및 맵초기화 reducer 설정
- store 생성
- root Element render시, Provider store 연결

### ETC
- 참고사항 : 실제 컴포넌트에서 사용될 구체적인 state 및 reducer은 개발단계에서 추가 설정 필요합니다.
