### PR TITLE
feat: 블록 drag&drop을 통한 element 생성기능 구현

### DIFF
--- a/src/components/BlockCombinator/index.js
+++ b/src/components/BlockCombinator/index.js
@@ -1,24 +1,83 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import { WINDOW } from "../../config/constants";
 
 function BlockCombinator() {
-  function BlockSelectionWindow() {
-    return <Title color={"#ffffff"}>{WINDOW.BLOCKS_SELECTION}</Title>;
-  }
+  const blocks = [
+    "1칸전진",
+    "왼쪽회전",
+    "오른쪽회전",
+    "if",
+    "while",
+    "공격",
+    "놓기",
+  ];
 
-  function BlockLogicWindow() {
-    return <Title color={"#000000"}>{WINDOW.BLOCKS_LOGIC}</Title>;
-  }
+  const [logicBlocks, setLogicBlocks] = useState(
+    Array.from({ length: 10 }).fill(""),
+  );
+
+  const dragStart = (event) => {
+    event.dataTransfer.setData("text", event.target.innerText);
+  };
+
+  const drop = (event) => {
+    const data = event.dataTransfer.getData("text");
+
+    if (data && logicBlocks.includes("")) {
+      const newLogicBlocks = logicBlocks.slice();
+
+      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, data);
+      setLogicBlocks(newLogicBlocks);
+    }
+  };
+
+  const allowDrop = (event) => {
+    event.preventDefault();
+  };
 
   return (
     <Wrapper>
       <WindowWrapper backGroundColor={"#64a9bd"}>
-        <BlockSelectionWindow />
+        <Title color={"#ffffff"}>{WINDOW.BLOCKS_SELECTION}</Title>
+        {blocks.map((blockTitle) => (
+          <Block
+            key={blockTitle}
+            id={blockTitle}
+            onDragStart={dragStart}
+            draggable="true"
+          >
+            {blockTitle}
+          </Block>
+        ))}
       </WindowWrapper>
-      <WindowWrapper backGroundColor={"#f5ed58"}>
-        <BlockLogicWindow />
+      <WindowWrapper
+        backGroundColor={"#f5ed58"}
+        onDrop={drop}
+        onDragOver={allowDrop}
+      >
+        <Title color={"#000000"} draggable="false">
+          {WINDOW.BLOCKS_LOGIC}
+        </Title>
+        {logicBlocks.map((blockTitle, index) =>
+          blockTitle ? (
+            <Block
+              key={`${blockTitle}${index}`}
+              id={`${blockTitle}${index}`}
+              draggable="true"
+            >
+              {blockTitle}
+            </Block>
+          ) : (
+            <EmptyBlock
+              key={`${blockTitle}${index}`}
+              id={`${blockTitle}${index}`}
+            >
+              {blockTitle}
+            </EmptyBlock>
+          ),
+        )}
       </WindowWrapper>
     </Wrapper>
   );
@@ -37,12 +96,41 @@ const Wrapper = styled.div`
 `;
 
 const WindowWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   width: 20vw;
   height: 70vh;
   margin-right: 3vw;
-  border: 0.3vw solid #000000;
+  border: 3px solid #000000;
   background-color: ${(props) => props.backGroundColor};
   box-shadow: 0vw 0.3vw 0.3vw rgba(0, 0, 0, 0.25);
+`;
+
+const Block = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 70%;
+  height: 2.5rem;
+  margin: 0.2rem 0;
+  border: 3px solid #000000;
+  background-color: #7e72ce;
+  color: white;
+  font-weight: bolder;
+`;
+
+const EmptyBlock = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 70%;
+  height: 2.5rem;
+  margin: 0.2rem 0;
+  border: 2px dashed #000000;
+  background-color: transparent;
+  color: white;
+  font-weight: bolder;
 `;
 
 export default BlockCombinator;

--- a/src/components/BlockCombinator/index.js
+++ b/src/components/BlockCombinator/index.js
@@ -102,7 +102,7 @@ const WindowWrapper = styled.div`
   width: 20vw;
   height: 70vh;
   margin-right: 3vw;
-  border: 3px solid #000000;
+  border: 0.3vw solid #000000;
   background-color: ${(props) => props.backGroundColor};
   box-shadow: 0vw 0.3vw 0.3vw rgba(0, 0, 0, 0.25);
 `;
@@ -114,8 +114,8 @@ const Block = styled.div`
   width: 70%;
   height: 2.5rem;
   margin: 0.2rem 0;
-  border: 3px solid #000000;
   background-color: #7e72ce;
+  border: 2px solid #000000;
   color: white;
   font-weight: bolder;
 `;


### PR DESCRIPTION
### Task Card
- [[Block] drag & drop으로 element 생성
](https://www.notion.so/vanillacoding/Block-drag-drop-element-8d169af11b90440bad30744168d45db8)

### Description
- `BlockCombinator` 컴포넌트에서 `코드블록 선택하기 컨테이너` ➡️ `코드 블록 놓기 컨테이너`로 Drag & Drop 시,
Element 복사생성 기능 구현

### ETC
- 참고사항
  - 블록 Element가 아닌 페이지내 텍스트를 블록지정하고 Drag & Drop시 해당 텍스트가 포함된 블럭이 생성되는 버그가 있습니다.
  블록관련 기능을 개발해 나가면서 해결해보겠습니다.
  
- 카드내용과 달라진점
  - `코드블록 선택하기 컨테이너`의 블록종류는 기존 redux를 참조해 가져오는 방식에서, 파일에서 데이터를 가져오는 방식으로 변경됐기 때문에 Todo 리스트에서 삭제했습니다.
