### PR TITLE
feat: 블록 위아래 순서 변경

### DIFF
--- a/src/components/BlockCombinator/index.js
+++ b/src/components/BlockCombinator/index.js
@@ -25,7 +25,7 @@ function BlockCombinator() {
   };
 
   const drop = (event) => {
-    const data = event.dataTransfer.getData("text");
+    const dragBlockText = event.dataTransfer.getData("text");
     const newLogicBlocks = logicBlocks.slice();
 
     if (
@@ -34,14 +34,14 @@ function BlockCombinator() {
       newLogicBlocks[dragOverBlock.current]
     ) {
       newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1);
-      newLogicBlocks.splice(dragOverBlock.current, 0, data);
+      newLogicBlocks.splice(dragOverBlock.current, 0, dragBlockText);
       setLogicBlocks(newLogicBlocks);
     } else if (
       newLogicBlocks.includes("") &&
       !blockId.includes("blocksLogic") &&
       !newLogicBlocks[dragOverBlock.current]
     ) {
-      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, data);
+      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, dragBlockText);
       setLogicBlocks(newLogicBlocks);
     }
 
@@ -50,14 +50,14 @@ function BlockCombinator() {
       newLogicBlocks[dragOverBlock.current]
     ) {
       newLogicBlocks.splice(blockIndex, 1);
-      newLogicBlocks.splice(dragOverBlock.current, 0, data);
+      newLogicBlocks.splice(dragOverBlock.current, 0, dragBlockText);
       setLogicBlocks(newLogicBlocks);
     } else if (
       blockId.includes("blocksLogic") &&
       !newLogicBlocks[dragOverBlock.current]
     ) {
       newLogicBlocks.splice(blockIndex, 1);
-      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, data);
+      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, dragBlockText);
       newLogicBlocks.push("");
       setLogicBlocks(newLogicBlocks);
     }
@@ -94,7 +94,7 @@ function BlockCombinator() {
           blockTitle ? (
             <Block
               key={`${blockTitle}${index}`}
-              id={`"blocksLogic${index}`}
+              id={`blocksLogic${index}`}
               draggable="true"
               onDragStart={(event) => dragStart(event, index)}
               onDragEnter={(event) => dragEnter(event, index)}
@@ -104,7 +104,7 @@ function BlockCombinator() {
           ) : (
             <EmptyBlock
               key={`${blockTitle}${index}`}
-              id={`${index}`}
+              id={`${blockTitle}${index}`}
               onDragEnter={(event) => dragEnter(event, index)}
             >
               {blockTitle}

--- a/src/components/BlockCombinator/index.js
+++ b/src/components/BlockCombinator/index.js
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from "react";
 import styled from "styled-components";
 
-import { ID, WINDOW } from "../../config/constants";
+import { WINDOW } from "../../config/constants";
 
 function BlockCombinator() {
   const dragOverBlock = useRef();
@@ -30,27 +30,35 @@ function BlockCombinator() {
 
     if (
       newLogicBlocks.includes("") &&
-      !blockId.includes(ID.BLOCKS_LOGIC) &&
-      !newLogicBlocks[dragOverBlock.current]
-    ) {
-      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, data);
-      setLogicBlocks(newLogicBlocks);
-    } else if (
-      newLogicBlocks.includes("") &&
-      !blockId.includes(ID.BLOCKS_LOGIC) &&
+      !blockId.includes("blocksLogic") &&
       newLogicBlocks[dragOverBlock.current]
     ) {
       newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1);
       newLogicBlocks.splice(dragOverBlock.current, 0, data);
       setLogicBlocks(newLogicBlocks);
+    } else if (
+      newLogicBlocks.includes("") &&
+      !blockId.includes("blocksLogic") &&
+      !newLogicBlocks[dragOverBlock.current]
+    ) {
+      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, data);
+      setLogicBlocks(newLogicBlocks);
     }
 
     if (
-      blockId.includes(ID.BLOCKS_LOGIC) &&
+      blockId.includes("blocksLogic") &&
       newLogicBlocks[dragOverBlock.current]
     ) {
       newLogicBlocks.splice(blockIndex, 1);
       newLogicBlocks.splice(dragOverBlock.current, 0, data);
+      setLogicBlocks(newLogicBlocks);
+    } else if (
+      blockId.includes("blocksLogic") &&
+      !newLogicBlocks[dragOverBlock.current]
+    ) {
+      newLogicBlocks.splice(blockIndex, 1);
+      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, data);
+      newLogicBlocks.push("");
       setLogicBlocks(newLogicBlocks);
     }
   };
@@ -86,7 +94,7 @@ function BlockCombinator() {
           blockTitle ? (
             <Block
               key={`${blockTitle}${index}`}
-              id={`${ID.BLOCKS_LOGIC}-${index}`}
+              id={`"blocksLogic${index}`}
               draggable="true"
               onDragStart={(event) => dragStart(event, index)}
               onDragEnter={(event) => dragEnter(event, index)}

--- a/src/components/BlockCombinator/index.js
+++ b/src/components/BlockCombinator/index.js
@@ -1,34 +1,56 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import styled from "styled-components";
 
-import { WINDOW } from "../../config/constants";
+import { ID, WINDOW } from "../../config/constants";
 
 function BlockCombinator() {
-  const blocks = [
-    "1칸전진",
-    "왼쪽회전",
-    "오른쪽회전",
-    "if",
-    "while",
-    "공격",
-    "놓기",
-  ];
+  const dragOverBlock = useRef();
+  const blocks = ["1칸전진", "오른쪽회전", "왼쪽회전", "공격", "if", "while"];
 
   const [logicBlocks, setLogicBlocks] = useState(
     Array.from({ length: 10 }).fill(""),
   );
 
-  const dragStart = (event) => {
+  let blockIndex;
+  let blockId;
+
+  const dragStart = (event, index) => {
     event.dataTransfer.setData("text", event.target.innerText);
+    blockIndex = index;
+    blockId = event.currentTarget.id;
+  };
+
+  const dragEnter = (event, index) => {
+    dragOverBlock.current = index;
   };
 
   const drop = (event) => {
     const data = event.dataTransfer.getData("text");
+    const newLogicBlocks = logicBlocks.slice();
 
-    if (data && logicBlocks.includes("")) {
-      const newLogicBlocks = logicBlocks.slice();
-
+    if (
+      newLogicBlocks.includes("") &&
+      !blockId.includes(ID.BLOCKS_LOGIC) &&
+      !newLogicBlocks[dragOverBlock.current]
+    ) {
       newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1, data);
+      setLogicBlocks(newLogicBlocks);
+    } else if (
+      newLogicBlocks.includes("") &&
+      !blockId.includes(ID.BLOCKS_LOGIC) &&
+      newLogicBlocks[dragOverBlock.current]
+    ) {
+      newLogicBlocks.splice(newLogicBlocks.indexOf(""), 1);
+      newLogicBlocks.splice(dragOverBlock.current, 0, data);
+      setLogicBlocks(newLogicBlocks);
+    }
+
+    if (
+      blockId.includes(ID.BLOCKS_LOGIC) &&
+      newLogicBlocks[dragOverBlock.current]
+    ) {
+      newLogicBlocks.splice(blockIndex, 1);
+      newLogicBlocks.splice(dragOverBlock.current, 0, data);
       setLogicBlocks(newLogicBlocks);
     }
   };
@@ -41,12 +63,12 @@ function BlockCombinator() {
     <Wrapper>
       <WindowWrapper backGroundColor={"#64a9bd"}>
         <Title color={"#ffffff"}>{WINDOW.BLOCKS_SELECTION}</Title>
-        {blocks.map((blockTitle) => (
+        {blocks.map((blockTitle, index) => (
           <Block
             key={blockTitle}
             id={blockTitle}
-            onDragStart={dragStart}
             draggable="true"
+            onDragStart={(event) => dragStart(event, index)}
           >
             {blockTitle}
           </Block>
@@ -64,15 +86,18 @@ function BlockCombinator() {
           blockTitle ? (
             <Block
               key={`${blockTitle}${index}`}
-              id={`${blockTitle}${index}`}
+              id={`${ID.BLOCKS_LOGIC}-${index}`}
               draggable="true"
+              onDragStart={(event) => dragStart(event, index)}
+              onDragEnter={(event) => dragEnter(event, index)}
             >
               {blockTitle}
             </Block>
           ) : (
             <EmptyBlock
               key={`${blockTitle}${index}`}
-              id={`${blockTitle}${index}`}
+              id={`${index}`}
+              onDragEnter={(event) => dragEnter(event, index)}
             >
               {blockTitle}
             </EmptyBlock>
@@ -111,7 +136,7 @@ const Block = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 70%;
+  width: 13vw;
   height: 2.5rem;
   margin: 0.2rem 0;
   background-color: #7e72ce;
@@ -124,7 +149,7 @@ const EmptyBlock = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 70%;
+  width: 13vw;
   height: 2.5rem;
   margin: 0.2rem 0;
   border: 2px dashed #000000;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -17,6 +17,10 @@ export const BUTTON = {
   START: "시작하기",
 };
 
+export const ID = {
+  BLOCKS_LOGIC: "blocksLogic",
+};
+
 export const WINDOW = {
   BLOCKS_SELECTION: "코드 블록 선택하기",
   BLOCKS_LOGIC: "코드 블록 놓기",

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -17,10 +17,6 @@ export const BUTTON = {
   START: "시작하기",
 };
 
-export const ID = {
-  BLOCKS_LOGIC: "blocksLogic",
-};
-
 export const WINDOW = {
   BLOCKS_SELECTION: "코드 블록 선택하기",
   BLOCKS_LOGIC: "코드 블록 놓기",


### PR DESCRIPTION
### Task Card
- [Block] drag & drop 블록 위아래 순서 변경](https://www.notion.so/vanillacoding/Block-drag-drop-d6bdad76af7d448188eb69b51d27338a)

### Description
- 코드 선택하기 컨테이너에서 블록 하나를 집어, 코드 블록 놓기 컨테이너 위 블록 사이에 drop 시 블록을 한 칸씩 밀어내고 해당 위치에 블록 삽입한다.
- 코드 블록 놓기 컨테이너 위 블록 중 블록 하나를 집어, 다른 블록 사이에 drop 시 그 사이로 블록 삽입한다.
- 컨테이너 위가 아닌 다른위치에 drop 시 무시한다.

### ETC
- 필요 없는 블록("놓기")을 삭제 및 블록 배열 내 순서를 피그마 시안과 맞게 변경했습니다.
- 스타일드 컴포넌트의 width와 height의 단위를 vw, vh로 통일했습니다.
