### PR TITLE
feat: header gamelist layout

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -5,7 +5,7 @@ import { createGlobalStyle } from "styled-components";
 import Home from "../pages/Home";
 import Tutorial from "../pages/Tutorial";
 import Game from "../pages/Game";
-import GameList from "../pages/GameList";
+import { GameList } from "../pages/GameList";
 import Error from "../pages/Error/Error";
 import NotFound from "../pages/NotFound";
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,19 +1,26 @@
 import React from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 
 import { LOGO, BUTTON } from "../../config/constants";
 
 function Header() {
+  const navigate = useNavigate();
+
   return (
     <Wrapper>
-      <Logo>
+      <Logo onClick={() => navigate("/", { replace: true })}>
         <TextWhite>{LOGO.C}</TextWhite>
         <TextYellow>{LOGO.O}</TextYellow>
         <TextWhite>{LOGO.BLOCKS}</TextWhite>
       </Logo>
       <ButtonWrapper>
-        <Button>{BUTTON.TUTORIAL}</Button>
-        <Button>{BUTTON.GAME_SELECTION}</Button>
+        <Button onClick={() => navigate("/tutorial/123", { replace: true })}>
+          {BUTTON.TUTORIAL}
+        </Button>
+        <Button onClick={() => navigate("/game_list", { replace: true })}>
+          {BUTTON.GAME_SELECTION}
+        </Button>
       </ButtonWrapper>
     </Wrapper>
   );

--- a/src/pages/GameList/index.js
+++ b/src/pages/GameList/index.js
@@ -60,9 +60,9 @@ const ListWrapper = styled.div`
 `;
 
 const GameTitleList = styled.p`
-  text-align: center;
+  margin: 1rem 0;
+  color: white;
   font-size: 5vh;
   font-weight: bolder;
-  color: white;
-  margin: 1rem 0;
+  text-align: center;
 `;

--- a/src/pages/GameList/index.js
+++ b/src/pages/GameList/index.js
@@ -15,9 +15,9 @@ function GameList() {
       <Header />
       <GuiedMessage>도전하고 싶은 맵을 선택하세요.</GuiedMessage>
       <ListWrapper>
-        {mapLists.map((maplist, index) => (
+        {mapLists.map((maplist) => (
           <GameTitleList
-            key={index}
+            key={maplist[0]}
             onClick={() => navigate(`/game/${maplist[0]}`, { replace: true })}
           >{`${maplist[0]}: ${maplist[1].title}`}</GameTitleList>
         ))}
@@ -26,7 +26,7 @@ function GameList() {
   );
 }
 
-export default GameList;
+export { GameList };
 
 const GuiedMessage = styled.p`
   display: flex;

--- a/src/pages/GameList/index.js
+++ b/src/pages/GameList/index.js
@@ -1,7 +1,68 @@
 import React from "react";
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+
+import Header from "../../components/Header";
+import mapsData from "../../data/mapData";
 
 function GameList() {
-  return <></>;
+  const navigate = useNavigate();
+
+  const mapLists = Object.entries({ ...mapsData });
+
+  return (
+    <>
+      <Header />
+      <GuiedMessage>도전하고 싶은 맵을 선택하세요.</GuiedMessage>
+      <ListWrapper>
+        {mapLists.map((maplist, index) => (
+          <GameTitleList
+            key={index}
+            onClick={() => navigate(`/game/${maplist[0]}`, { replace: true })}
+          >{`${maplist[0]}: ${maplist[1].title}`}</GameTitleList>
+        ))}
+      </ListWrapper>
+    </>
+  );
 }
 
 export default GameList;
+
+const GuiedMessage = styled.p`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 10vh;
+  font-size: 1.5vw;
+  font-weight: bolder;
+`;
+
+const ListWrapper = styled.div`
+  align-items: center;
+  justify-content: space-between;
+  height: 82vh;
+  margin: 0 10vw 0 10vw;
+  padding: 3vw;
+  border: 0.3vw solid #000000;
+  background: #393fb3;
+  box-shadow: 0vw 0.3vw 0.3vw rgba(0, 0, 0, 0.25);
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.4);
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 6px;
+  }
+`;
+
+const GameTitleList = styled.p`
+  text-align: center;
+  font-size: 5vh;
+  font-weight: bolder;
+  color: white;
+  margin: 1rem 0;
+`;


### PR DESCRIPTION
### Task Card
- [[Layout] 게임 선택, 헤더 컴포넌트 생성 및 배치](https://www.notion.so/vanillacoding/Layout-c0d9834ecfe2433498f8949bbdd70a49)

### Description
- header 네비게이터 기능 추가
- gamelist 레이아웃 구현
- gamelist에서 mapdata로 stage, title 목록 표현
- 해당 목록 클릭시 선택한 맵을 즐길 수 있는 game page로 이동하도록 구현. 

### ETC
- 참고사항
  - 튜토리얼의 첫 스테이지 주소가 정해지지 않아서 임의의 값이 들어 있습니다.
