### PR TITLE
feat: 다시하기 기능 구현

### DIFF
--- a/src/components/BlockCombinator/index.js
+++ b/src/components/BlockCombinator/index.js
@@ -63,6 +63,7 @@ function BlockCombinator({
 
   useEffect(() => {
     setLogicBlocks([]);
+    setIsBlockFreezed(false);
   }, [mapId]);
 
   useEffect(() => {

--- a/src/components/BlockCombinator/index.js
+++ b/src/components/BlockCombinator/index.js
@@ -383,6 +383,8 @@ function BlockCombinator({
     if (!isBlockFreezed) {
       setLogicBlocks([]);
       setBlocksCount(limitCount);
+      selectOptionRef.current = {};
+      repeatCountRef.current = {};
     }
   };
 

--- a/src/components/BlockCombinator/index.js
+++ b/src/components/BlockCombinator/index.js
@@ -11,7 +11,6 @@ import { sleep } from "../../utils/sleep";
 
 function BlockCombinator({
   submittedBlockInfo,
-  setSubmittedBlockInfo,
   availableBlocks,
   limitCount,
   mapId,
@@ -52,8 +51,9 @@ function BlockCombinator({
   useEffect(() => {
     if (submittedBlockInfo) {
       translateBlocks();
-      setSubmittedBlockInfo(!submittedBlockInfo);
-      setIsBlockFreezed(!isBlockFreezed);
+      setIsBlockFreezed(true);
+    } else {
+      setIsBlockFreezed(false);
     }
   }, [submittedBlockInfo]);
 
@@ -64,6 +64,7 @@ function BlockCombinator({
   useEffect(() => {
     setLogicBlocks([]);
     setIsBlockFreezed(false);
+    setBlocksCount(limitCount);
   }, [mapId]);
 
   useEffect(() => {
@@ -378,6 +379,13 @@ function BlockCombinator({
     dispatch(updateTranslatedBlocks(translatedBlocks));
   };
 
+  const clearLogicBlock = () => {
+    if (!isBlockFreezed) {
+      setLogicBlocks([]);
+      setBlocksCount(limitCount);
+    }
+  };
+
   return (
     <Wrapper>
       <SelectionBlocks onDrop={removeLogicBlock} onDragOver={allowDrop}>
@@ -412,8 +420,9 @@ function BlockCombinator({
         onDrop={handleBlock}
         onDragOver={allowDrop}
       >
-        <Title color={"#000000"} draggable={!isBlockFreezed}>
+        <Title color={"#000000"}>
           {WINDOW.BLOCKS_LOGIC}
+          <ClearButton onClick={clearLogicBlock}>🗑️</ClearButton>
         </Title>
         {logicBlocks.map((blockType, index) =>
           blockType === IF ? (
@@ -537,6 +546,17 @@ const Title = styled.div`
   font-size: 1.8vw;
   font-weight: bolder;
   text-align: center;
+`;
+
+const ClearButton = styled.button`
+  background-color: transparent;
+  border: none;
+  font-size: 1.8vw;
+  transition: all 300ms;
+
+  &:hover {
+    transform: scale(1.1) rotate(180deg);
+  }
 `;
 
 const Wrapper = styled.div`

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -27,6 +27,7 @@ function Map({
   const isEnded = useRef(false);
   const character = useRef({ x: 0, y: 0, direction: 0 });
   const newMapInfo = useRef(cloneDeep(mapInfo));
+  const keyQuantityRef = useRef(keyQuantity);
   const dispatch = useDispatch();
   const selectTranslatedBlocks = useSelector(
     (state) => state.block.translatedBlocks,
@@ -368,6 +369,7 @@ function Map({
   };
 
   const moveOneTile = async () => {
+    console.log("keyQuantity=", keyQuantityRef.current);
     const context = ref.current.getContext("2d");
     const forwardTileType = getTileTypeOfSelectDirection(
       character,
@@ -404,6 +406,7 @@ function Map({
     };
 
     if (forwardTileType === "key") {
+      keyQuantityRef.current = keyQuantity + 1;
       setKeyQuantity(keyQuantity + 1);
 
       replaceAsset(DELETE_ELEMENT);
@@ -412,10 +415,11 @@ function Map({
     }
 
     if (forwardTileType === "closedDoor") {
-      if (keyQuantity > 0) {
+      if (keyQuantityRef.current > 0) {
         replaceAsset(OPEN_DOOR);
 
-        setKeyQuantity(keyQuantity - 1);
+        setKeyQuantity(keyQuantityRef.current - 1);
+        keyQuantityRef.current--;
       } else {
         setResultMessage(FAIL);
 

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -3,7 +3,10 @@ import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import cloneDeep from "lodash/cloneDeep";
 
-import { updateExecutingBlock } from "../../features/block/blockSlice";
+import {
+  updateExecutingBlock,
+  resetTranslatedBlocks,
+} from "../../features/block/blockSlice";
 import { sleep } from "../../utils/sleep";
 
 import {
@@ -117,6 +120,10 @@ function Map({
   }, [selectTranslatedBlocks]);
 
   useEffect(() => {
+    dispatch(resetTranslatedBlocks());
+    isEnded.current = true;
+    setTimeout(() => (isEnded.current = false), BLOCK_EXECUTION_TERM);
+
     newMapInfo.current = cloneDeep(mapInfo);
     mapAsset.addEventListener(
       "load",

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -6,7 +6,9 @@ import cloneDeep from "lodash/cloneDeep";
 import {
   updateExecutingBlock,
   resetTranslatedBlocks,
+  resetExecutingBlock,
 } from "../../features/block/blockSlice";
+
 import { sleep } from "../../utils/sleep";
 
 import {
@@ -30,7 +32,10 @@ function Map({
   const isEnded = useRef(false);
   const character = useRef({ x: 0, y: 0, direction: 0 });
   const newMapInfo = useRef(cloneDeep(mapInfo));
+  const catAsset = useRef(new Image());
+  const mapAsset = useRef(new Image());
   const keyQuantityRef = useRef(keyQuantity);
+
   const dispatch = useDispatch();
   const selectTranslatedBlocks = useSelector(
     (state) => state.block.translatedBlocks,
@@ -65,12 +70,6 @@ function Map({
   const { BLOCK_EXECUTION_TERM, MODAL_OPENING_DELAY } = SLEEP_TIME;
   const { MOVE, TURN_RIGHT, TURN_LEFT, ATTACK, WHILE, REPEAT } = BLOCK_NAMES;
 
-  const catAsset = new Image();
-  const mapAsset = new Image();
-
-  catAsset.src = "/assets/image/cat_asset.png";
-  mapAsset.src = "/assets/image/map_asset.png";
-
   useEffect(() => {
     (async () => {
       for (
@@ -78,7 +77,7 @@ function Map({
         blockIndex < selectTranslatedBlocks.length;
         blockIndex++
       ) {
-        if (isEnded.current) break;
+        if (isEnded.current) return;
 
         const block = selectTranslatedBlocks[blockIndex];
 
@@ -120,12 +119,16 @@ function Map({
   }, [selectTranslatedBlocks]);
 
   useEffect(() => {
+    catAsset.current.src = "/assets/image/cat_asset.png";
+    mapAsset.current.src = "/assets/image/map_asset.png";
+
     dispatch(resetTranslatedBlocks());
+    dispatch(resetExecutingBlock());
     isEnded.current = true;
-    setTimeout(() => (isEnded.current = false), BLOCK_EXECUTION_TERM);
+    setTimeout(() => (isEnded.current = false), BLOCK_EXECUTION_TERM * 2);
 
     newMapInfo.current = cloneDeep(mapInfo);
-    mapAsset.addEventListener(
+    mapAsset.current.addEventListener(
       "load",
       () => {
         const { x: startingCoordinateX, y: startingCoordinateY } =
@@ -145,7 +148,7 @@ function Map({
               getAssetCoordinate(mapElement);
 
             drawField({
-              image: mapAsset,
+              image: mapAsset.current,
               mapCoordinateX,
               mapCoordinateY,
               assetCoordinateX: mapInfo.defaultField,
@@ -154,7 +157,7 @@ function Map({
 
             if (mapElement !== -1) {
               drawField({
-                image: mapAsset,
+                image: mapAsset.current,
                 mapCoordinateX,
                 mapCoordinateY,
                 assetCoordinateX,
@@ -165,7 +168,7 @@ function Map({
         }
 
         drawField({
-          image: catAsset,
+          image: catAsset.current,
           mapCoordinateX: startingCoordinateX,
           mapCoordinateY: startingCoordinateY,
           assetCoordinateX: 0,
@@ -287,7 +290,7 @@ function Map({
       getAssetCoordinate(element);
 
     drawField({
-      image: mapAsset,
+      image: mapAsset.current,
       mapCoordinateX: newCharacter.x,
       mapCoordinateY: newCharacter.y,
       assetCoordinateX,
@@ -295,7 +298,7 @@ function Map({
     });
 
     drawField({
-      image: catAsset,
+      image: catAsset.current,
       mapCoordinateX: newCharacter.x,
       mapCoordinateY: newCharacter.y,
       assetCoordinateX: 0,
@@ -376,7 +379,6 @@ function Map({
   };
 
   const moveOneTile = async () => {
-    console.log("keyQuantity=", keyQuantityRef.current);
     const context = ref.current.getContext("2d");
     const forwardTileType = getTileTypeOfSelectDirection(
       character,
@@ -461,7 +463,7 @@ function Map({
         getAssetCoordinate(mapElement);
 
       drawField({
-        image: mapAsset,
+        image: mapAsset.current,
         mapCoordinateX: character.current.x,
         mapCoordinateY: character.current.y,
         assetCoordinateX,
@@ -469,7 +471,7 @@ function Map({
       });
 
       drawField({
-        image: mapAsset,
+        image: mapAsset.current,
         mapCoordinateX: nextCharacter.x,
         mapCoordinateY: nextCharacter.y,
         assetCoordinateX: forwardAssetCoordinate.x,
@@ -477,7 +479,7 @@ function Map({
       });
 
       context.drawImage(
-        catAsset,
+        catAsset.current,
         (i % CAT_SPRITE_FRAMES) * SINGLE_ASSET_WIDTH,
         SINGLE_ASSET_HEIGHT * nextCharacter.direction,
         SINGLE_ASSET_WIDTH,
@@ -498,7 +500,7 @@ function Map({
     }
 
     if (forwardTileType === "water") {
-      drown(nextCharacter.x, nextCharacter.y);
+      await drown(nextCharacter.x, nextCharacter.y);
     }
 
     character.current = nextCharacter;
@@ -531,7 +533,7 @@ function Map({
 
     for (let i = 0; i < CAT_SPRITE_FRAMES; i++) {
       drawField({
-        image: catAsset,
+        image: catAsset.current,
         mapCoordinateX: coordinateX,
         mapCoordinateY: coordinateY,
         assetCoordinateX: i,
@@ -577,7 +579,7 @@ function Map({
 
       for (let i = 0; i < CAT_SPRITE_FRAMES; i++) {
         drawField({
-          image: mapAsset,
+          image: mapAsset.current,
           mapCoordinateX: nextCharacter.x,
           mapCoordinateY: nextCharacter.y,
           assetCoordinateX: i,
@@ -588,7 +590,7 @@ function Map({
       }
 
       drawField({
-        image: mapAsset,
+        image: mapAsset.current,
         mapCoordinateX: nextCharacter.x,
         mapCoordinateY: nextCharacter.y,
         assetCoordinateX: mapInfo.defaultField,
@@ -601,7 +603,7 @@ function Map({
       const catPaw = Math.floor(PAW / 10);
       for (let i = 0; i < CAT_SPRITE_FRAMES; i++) {
         drawField({
-          image: mapAsset,
+          image: mapAsset.current,
           mapCoordinateX: nextCharacter.x,
           mapCoordinateY: nextCharacter.y,
           assetCoordinateX: i,
@@ -616,7 +618,7 @@ function Map({
       );
 
       drawField({
-        image: mapAsset,
+        image: mapAsset.current,
         mapCoordinateX: nextCharacter.x,
         mapCoordinateY: nextCharacter.y,
         assetCoordinateX: assetCoordinateX,

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -12,7 +12,7 @@ export const STARS = {
 export const BUTTON = {
   TUTORIAL: "연습하기",
   GAME_SELECTION: "게임선택",
-  REPEAT: "다시하기",
+  RESTART: "다시하기",
   NEXT_GAME: "다음게임",
   START: "시작하기",
 };

--- a/src/features/block/blockSlice.js
+++ b/src/features/block/blockSlice.js
@@ -10,6 +10,9 @@ const blockSlice = createSlice({
     resetTranslatedBlocks: (state) => {
       state.translatedBlocks = [];
     },
+    resetExecutingBlock: (state) => {
+      state.executingBlock = "";
+    },
     updateTranslatedBlocks: (state, action) => {
       state.translatedBlocks = action.payload;
     },
@@ -22,6 +25,7 @@ const blockSlice = createSlice({
 export { blockSlice };
 export const {
   resetTranslatedBlocks,
+  resetExecutingBlock,
   updateTranslatedBlocks,
   updateExecutingBlock,
 } = blockSlice.actions;

--- a/src/pages/Tutorial/index.js
+++ b/src/pages/Tutorial/index.js
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useNavigate, useParams } from "react-router-dom";
 import cloneDeep from "lodash/cloneDeep";
+import { useDispatch } from "react-redux";
 
+import {
+  resetTranslatedBlocks,
+  updateExecutingBlock,
+} from "../../features/block/blockSlice";
 import { tutorialMapsData } from "../../mapInfo/tutorialMapsData";
 
 import { Modal } from "../../components/Modal/Modal";
@@ -13,6 +18,7 @@ import { Map } from "../../components/Map";
 import { STARS, BUTTON, MESSAGE } from "../../config/constants";
 
 function Tutorial() {
+  const dispatch = useDispatch();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSubmit, setIsSubmit] = useState(false);
   const [resultMessage, setResultMessage] = useState("");
@@ -24,21 +30,20 @@ function Tutorial() {
   const allTutorialKeys = Object.keys(tutorialMapsData);
 
   const [mapData, setMapData] = useState(
-    cloneDeep(tutorialMapsData[tutorialId]),
+    tutorialMapsData[tutorialId] && cloneDeep(tutorialMapsData[tutorialId]),
   );
-
-  useEffect(() => {
-    setMapData(cloneDeep(tutorialMapsData[tutorialId]));
-  }, [tutorialId]);
 
   useEffect(() => {
     if (!tutorialMapsData[tutorialId]) {
       navigate("/not_found");
     }
-  }, []);
+
+    setMapData(cloneDeep(tutorialMapsData[tutorialId]));
+  }, [tutorialId]);
 
   const moveNextStage = () => {
     const currentIndex = allTutorialKeys.indexOf(tutorialId);
+
     if (currentIndex + 1 === allTutorialKeys.length) {
       setResultMessage(MESSAGE.LAST_STAGE);
       setIsModalOpen(!isModalOpen);
@@ -47,6 +52,17 @@ function Tutorial() {
         replace: true,
       });
     }
+  };
+
+  const restart = () => {
+    dispatch(updateExecutingBlock("end"));
+    dispatch(resetTranslatedBlocks());
+    setMapData(cloneDeep(tutorialMapsData[tutorialId]));
+    setIsSubmit(false);
+  };
+
+  const start = () => {
+    setIsSubmit(true);
   };
 
   return (
@@ -78,10 +94,12 @@ function Tutorial() {
                 </Star>
               ),
             )}
-            <Tip>Tip: {mapData.tip}</Tip>
+            <Tip>Tip: {mapData?.tip}</Tip>
           </GuideWrapper>
           <ButtonsWrapper>
-            <Button rightMargin={"4vw"}>{BUTTON.REPEAT}</Button>
+            <Button onClick={restart} rightMargin={"4vw"}>
+              {BUTTON.RESTART}
+            </Button>
             <Button rightMargin={"15vw"} onClick={moveNextStage}>
               {BUTTON.NEXT_GAME}
             </Button>
@@ -91,8 +109,8 @@ function Tutorial() {
           <BlockCombinator
             submittedBlockInfo={isSubmit}
             setSubmittedBlockInfo={setIsSubmit}
-            availableBlocks={mapData.blocks}
-            limitCount={mapData.limitCount}
+            availableBlocks={mapData?.blocks || []}
+            limitCount={mapData?.limitCount || 10}
             mapId={tutorialId}
           />
           <RightWrapper>
@@ -107,9 +125,7 @@ function Tutorial() {
               />
             )}
             열쇠: {keyQuantity}
-            <Button onClick={() => setIsSubmit(!isSubmit)}>
-              {BUTTON.START}
-            </Button>
+            <Button onClick={start}>{BUTTON.START}</Button>
           </RightWrapper>
         </ContentsWrapper>
       </Wrapper>

--- a/src/pages/Tutorial/index.js
+++ b/src/pages/Tutorial/index.js
@@ -6,6 +6,7 @@ import { useDispatch } from "react-redux";
 
 import {
   resetTranslatedBlocks,
+  resetExecutingBlock,
   updateExecutingBlock,
 } from "../../features/block/blockSlice";
 import { tutorialMapsData } from "../../mapInfo/tutorialMapsData";
@@ -39,9 +40,13 @@ function Tutorial() {
     }
 
     setMapData(cloneDeep(tutorialMapsData[tutorialId]));
+    setIsSubmit(false);
   }, [tutorialId]);
 
   const moveNextStage = () => {
+    dispatch(resetExecutingBlock());
+    dispatch(resetTranslatedBlocks());
+
     const currentIndex = allTutorialKeys.indexOf(tutorialId);
 
     if (currentIndex + 1 === allTutorialKeys.length) {
@@ -65,6 +70,15 @@ function Tutorial() {
     setIsSubmit(true);
   };
 
+  const handleStarClick = (stage) => {
+    dispatch(updateExecutingBlock("end"));
+    dispatch(resetTranslatedBlocks());
+    setMapData(cloneDeep(tutorialMapsData[tutorialId]));
+    setIsSubmit(false);
+
+    navigate(`/tutorial/${stage}`, { replace: true });
+  };
+
   return (
     <>
       {isModalOpen && (
@@ -86,9 +100,7 @@ function Tutorial() {
                 <Star
                   color={"#808080"}
                   key={`tutorial${tutorialId}-${index}`}
-                  onClick={() =>
-                    navigate(`/tutorial/${stage}`, { replace: true })
-                  }
+                  onClick={() => handleStarClick(stage)}
                 >
                   {STARS.EMPTY_STAR}
                 </Star>


### PR DESCRIPTION
### Task Card
- [[Function] 다시하기 기능 구현](https://www.notion.so/vanillacoding/Function-251757a068e94c0b8f5ecd7386f9057c)
- [(추가) 블록 함수 실행중단 케이스별 처리](https://www.notion.so/vanillacoding/fc607a47b7e444668927d509a2d24c67)

### Description
-  게임 페이지의 다시하기 버튼을 구현한다.
  - `Map` 컴포넌트 진행상태 초기화
  - 블록 함수가 진행중 상태였다면 중단 

### ETC
- 참고사항
  - 처리불가한 엣지케이스가 있습니다. ( 스프라이트 구현방식의 한계로 인해 캐릭터 이동모션 도중 페이지 넘기기, 다시하기 시 잔상이 남는 문제가 있습니다. )
- 기존 카드내용과 달라진점
  - 블록함수 동작중 stale closure로 인한 key 개수 업데이트 안되던 버그 수정
  - 다음게임 이동시 Drag & Drop 불가능하던 버그 수정
  - 블록 비우기 버튼 구현
  - 스테이지 이동시 맵 변경되지 않는 버그 수정
